### PR TITLE
Fix compatibility with Python 3.11

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -60,9 +60,8 @@ class Analysis:
             """
 
             callgraph_url = pkg.get("callgraph")
-            filename = f"{self.download_path.as_posix()}/{
-                pkg.get('purl').replace(':', '_').replace('/', '_').replace('@', '_')
-            }.json"
+            safe_purl = pkg.get('purl').replace(':', '_').replace('/', '_').replace('@', '_')
+            filename = f"{self.download_path.as_posix()}/{safe_purl}.json"
             subprocess.run(
                 ["curl", "-o", filename, callgraph_url],
                 # f"curl -o '{filename}' '{callgraph_url}'",

--- a/function.py
+++ b/function.py
@@ -59,11 +59,9 @@ class Function:
             match self.language:
                 # build a dynamic pattern using regular expression in the canonical format from the functino object
                 case "java":
-                    pattern = rf"{
-                        '' if self.package == '' else re.escape(self.package + '.')
-                    }{re.escape(self.type)}[.#]{self.function}\({
-                        ', *'.join([re.escape(p) for p in self.parameterTypes])
-                    }\)"
+                    escaped_package = '' if self.package == '' else re.escape(self.package + '.')
+                    escaped_parameterTypes = ', *'.join([re.escape(p) for p in self.parameterTypes])
+                    pattern = rf"{escaped_package}{re.escape(self.type)}[.#]{self.function}\({escaped_parameterTypes}\)"
 
                 case _:
                     return False


### PR DESCRIPTION
The script is mostly compatible with Python 3.11, but two call sites rely on **multiline f-string expressions**, a feature introduced only in **Python 3.12 (PEP 701)**.

This PR refactors those f-strings into regular string-concatenation templates, restoring full compatibility with Python 3.11 without changing behavior.